### PR TITLE
2x `CoverageCleaner` speed up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.openjump</groupId>
     <artifactId>topology-extension</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/com/vividsolutions/jcs/conflate/boundarymatch/SegmentMatcher.java
+++ b/src/main/java/com/vividsolutions/jcs/conflate/boundarymatch/SegmentMatcher.java
@@ -77,8 +77,8 @@ public class SegmentMatcher {
      * (LineSegment.angle returns an angle in the range [-PI, PI]
      */
     public static double angleDiff(LineSegment seg0, LineSegment seg1) {
-        double a0 = normalizedAngle(seg0.angle());
-        double a1 = normalizedAngle(seg1.angle());
+        double a0 = normalizedAngle(segmentAngleFast(seg0));
+        double a1 = normalizedAngle(segmentAngleFast(seg1));
         double delta = Math.min(normalizedAngle(a0-a1), normalizedAngle(a1-a0));
         return delta;
     }
@@ -190,5 +190,31 @@ public class SegmentMatcher {
         if (pos0 <= 0.0 && pos1 <= 0.0) return false;
         return true;
     }
+    
+	private static double segmentAngleFast(LineSegment l) {
+		return atan2Quick(l.p1.y - l.p0.y, l.p1.x - l.p0.x);
+	}
+
+	private static double atan2Quick(final double y, final double x) {
+		final double THREE_QRTR_PI = Math.PI * 0.75;
+		final double QRTR_PI = Math.PI * 0.25;
+
+		double r, angle;
+		final double abs_y = Math.abs(y) + 1e-10f; // kludge to prevent 0/0 condition
+
+		if (x < 0.0f) {
+			r = (x + abs_y) / (abs_y - x); // (3)
+			angle = THREE_QRTR_PI; // (4)
+		} else {
+			r = (x - abs_y) / (x + abs_y); // (1)
+			angle = QRTR_PI; // (2)
+		}
+		angle += (0.1963f * r * r - 0.9817f) * r; // (2 | 4)
+		if (y < 0.0f) {
+			return (-angle); // negate if in quad III or IV
+		} else {
+			return (angle);
+		}
+	}
 
 }

--- a/src/main/java/com/vividsolutions/jcs/conflate/coverage/Coverage.java
+++ b/src/main/java/com/vividsolutions/jcs/conflate/coverage/Coverage.java
@@ -121,10 +121,10 @@ public class Coverage {
                 // polygon into a MultiPolygon (only if it is noded)
                 if (!g.isValid()) g = g.buffer(0);
                 // don't update geometry if it's not valid
-                Debug.println("    adjusted geometry for : " + cgf.getFeature().getID() + " " +
-                    ((g==null)?"g=null   ":"g!=null   ") + (g.isValid()?"g.isValid()":"!g.isValid()"));
-                Feature originalFeat = cgf.getFeature();
-                Feature f = originalFeat.clone(false);
+//                Debug.println("    adjusted geometry for : " + cgf.getFeature().getID() + " " +
+//                    ((g==null)?"g=null   ":"g!=null   ") + (g.isValid()?"g.isValid()":"!g.isValid()"));
+                Feature f = cgf.getFeature();
+//                Feature f = originalFeat.clone(false);
                 f.setGeometry(g);
                 adjustedFC.add(f);
                 // record this feature as an update to the original

--- a/src/main/java/com/vividsolutions/jcs/conflate/coverage/Shell.java
+++ b/src/main/java/com/vividsolutions/jcs/conflate/coverage/Shell.java
@@ -150,11 +150,11 @@ public class Shell extends GeometryComponent {
     public boolean match(Shell shell, SegmentMatcher segmentMatcher,
                                       SegmentIndex matchedSegmentIndex) {
         if (segmentMatcher == null) {
-            Debug.println("Segment matcher should not be null !");
+//            Debug.println("Segment matcher should not be null !");
             return false;
         }
         else if (matchedSegmentIndex == null) {
-            Debug.println("matchedSegmentIndex should not be null !");
+//            Debug.println("matchedSegmentIndex should not be null !");
             return false;
         }
         // this method might cause the coordinates to change, so make sure they are recomputed
@@ -224,7 +224,7 @@ public class Shell extends GeometryComponent {
         // already computed
         if (adjustedCoord != null) return;
         CoordinateList coordList = new CoordinateList();
-        Debug.println("      Adjust coordinates for " + featureID + "/" + shellIndex);
+//        Debug.println("      Adjust coordinates for " + featureID + "/" + shellIndex);
         // For each segment of this Shell
         for (int i = 0; i < segments.length; i++) {
             Coordinate pt = getAdjustedCoordinate(i);
@@ -234,13 +234,13 @@ public class Shell extends GeometryComponent {
             }
             // add first coordinate
             coordList.add(pt, false);
-            if (!pt.equals(uniqueCoord[i])) {
-                Debug.println("        " + i + " : move " + uniqueCoord[i] + " -> " + pt);
-            }
+//            if (!pt.equals(uniqueCoord[i])) {
+//                Debug.println("        " + i + " : move " + uniqueCoord[i] + " -> " + pt);
+//            }
             if (segments[i] != null) {
                 // add inserted coordinates
                 coordList.addAll(segments[i].getInsertedCoordinates(interpolate_z, scale), false);
-                Debug.println("        " + i + " : insert " + segments[i].getInsertedCoordinates(interpolate_z, scale));
+//                Debug.println("        " + i + " : insert " + segments[i].getInsertedCoordinates(interpolate_z, scale));
             } 
         }
         coordList.closeRing();

--- a/src/main/java/com/vividsolutions/jcs/qa/InternalMatchedSegmentFinder.java
+++ b/src/main/java/com/vividsolutions/jcs/qa/InternalMatchedSegmentFinder.java
@@ -384,10 +384,10 @@ public class InternalMatchedSegmentFinder {
             if (zeroLength) continue;
             
             boolean isMatch = segmentMatcher.isMatch(fs, candidateFS);
-            Debug.println("       -> " + candidateFS);
+//            Debug.println("       -> " + candidateFS);
             if (isMatch && !isEqual && !zeroLength) {
                 hasMatch = true;
-                Debug.println(" MATCH !");
+//                Debug.println(" MATCH !");
                 //System.out.println("match : " + fs.getFeature().getID()+"|"+fs.toString() + " - " + candidateFS.getFeature().getID()+"|"+candidateFS.toString());
                 //System.out.println("   checkMatch=true for " + fs + " / " + candidateFS);
                 // save matched segments for future processing
@@ -402,7 +402,7 @@ public class InternalMatchedSegmentFinder {
                     }
                 }
             }
-            else Debug.println("");
+//            else Debug.println("");
         }
         return hasMatch;
     }


### PR DESCRIPTION
- Remove expensive calls to `LineSegment.angle()` (which in turn calls `atan2()`) and replace with fast approximate routine.
- Disable debug statements in hot areas. The problem here is Java is using `Stringbuilder` to build the strings that are passed into the `Debug.println()` method, adding a non-negligible amount of overhead. Ideally the debug flag would be at the source level to prevent strings being built when debugging is disabled.