### PR TITLE
Speed improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.openjump</groupId>
       <artifactId>OpenJUMP</artifactId>
-      <version>2.0-main-SNAPSHOT</version>
+      <version>2.2.0-main-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/vividsolutions/jcs/conflate/boundarymatch/SegmentMatcher.java
+++ b/src/main/java/com/vividsolutions/jcs/conflate/boundarymatch/SegmentMatcher.java
@@ -142,6 +142,16 @@ public class SegmentMatcher {
      */
     public boolean isMatch(LineSegment seg1, LineSegment seg2) {
         boolean isMatch = true;
+        LineSegment projSeg1 = seg2.project(seg1);
+        LineSegment projSeg2 = seg1.project(seg2);
+        if (projSeg1 == null || projSeg2 == null) {
+        	return false;
+        }
+        
+        double hDiff = hausdorffDistance(projSeg1, projSeg2);
+        if (hDiff > distanceTolerance) {
+        	return false;
+        }
         double dAngle = angleDiff(seg1, seg2);
         double dAngleInv = angleDiff(new LineSegment(seg1.p1, seg1.p0), seg2);
         switch (segmentOrientation) {
@@ -162,17 +172,6 @@ public class SegmentMatcher {
                 break;
         }
 
-        LineSegment projSeg1 = seg2.project(seg1);
-        LineSegment projSeg2 = seg1.project(seg2);
-        if (projSeg1 == null || projSeg2 == null) {
-            return false;
-        }
-
-//        double hDiff = new DiscreteHausdorffDistance(projSeg1.toGeometry(FACTORY), projSeg2.toGeometry(FACTORY)).distance();
-        double hDiff = hausdorffDistance(projSeg1, projSeg2);
-        if (hDiff > distanceTolerance) {
-            isMatch = false;
-        }
         return isMatch;
     }
     

--- a/src/main/java/com/vividsolutions/jcs/conflate/boundarymatch/SegmentMatcher.java
+++ b/src/main/java/com/vividsolutions/jcs/conflate/boundarymatch/SegmentMatcher.java
@@ -32,7 +32,6 @@
 
 package com.vividsolutions.jcs.conflate.boundarymatch;
 
-import org.locationtech.jts.algorithm.distance.DiscreteHausdorffDistance;
 import org.locationtech.jts.geom.*;
 import com.vividsolutions.jump.geom.*;
 
@@ -46,7 +45,6 @@ public class SegmentMatcher {
     public static final int SAME_ORIENTATION = 1;
     public static final int OPPOSITE_ORIENTATION = 2;
     public static final int EITHER_ORIENTATION = 3;
-    private static final GeometryFactory FACTORY = new GeometryFactory();
 
     public static boolean isCloseTo(Coordinate coord, LineSegment seg, double tolerance) {
         return coord.distance(seg.getCoordinate(0)) < tolerance ||
@@ -170,12 +168,14 @@ public class SegmentMatcher {
             return false;
         }
 
-        if (new DiscreteHausdorffDistance(projSeg1.toGeometry(FACTORY), projSeg2.toGeometry(FACTORY)).distance() > distanceTolerance) {
+//        double hDiff = new DiscreteHausdorffDistance(projSeg1.toGeometry(FACTORY), projSeg2.toGeometry(FACTORY)).distance();
+        double hDiff = hausdorffDistance(projSeg1, projSeg2);
+        if (hDiff > distanceTolerance) {
             isMatch = false;
         }
         return isMatch;
     }
-
+    
     /**
      * Test whether there is an overlap between the segments in either direction.
      * A segment overlaps another if it projects onto the segment.
@@ -230,5 +230,15 @@ public class SegmentMatcher {
         }
         return Math.copySign(th, y); // [-π,π]
     }
+
+	private static double hausdorffDistance(final LineSegment s1, final LineSegment s2) {
+	    double maxDist1 = 0.0;
+	    double maxDist2 = 0.0;
+	    maxDist1 = Math.max(s1.distance(s2.p0), maxDist1);
+	    maxDist1 = Math.max(s1.distance(s2.p1), maxDist1);
+	    maxDist2 = Math.max(s2.distance(s1.p0), maxDist2);
+	    maxDist2 = Math.max(s2.distance(s1.p1), maxDist2);
+	    return Math.max(maxDist1, maxDist2);
+	}
 
 }

--- a/src/main/java/com/vividsolutions/jcs/conflate/coverage/Shell.java
+++ b/src/main/java/com/vividsolutions/jcs/conflate/coverage/Shell.java
@@ -35,7 +35,6 @@ package com.vividsolutions.jcs.conflate.coverage;
 import com.vividsolutions.jcs.conflate.boundarymatch.SegmentMatcher;
 import com.vividsolutions.jcs.qa.FeatureSegment;
 import org.locationtech.jts.geom.*;
-import org.locationtech.jts.geomgraph.index.MonotoneChain;
 import org.locationtech.jts.index.strtree.STRtree;
 import java.util.Set;
 
@@ -199,9 +198,11 @@ public class Shell extends GeometryComponent {
 				LineSegment lineSeg1 = seg1.getLineSegment();
 
 				boolean isMatch = segmentMatcher.isMatch(lineSeg0, lineSeg1);
-				boolean isTopoEqual = lineSeg0.equalsTopo(lineSeg1);
-				if (isMatch && !isTopoEqual) {
-					isAdjusted |= seg0.addMatchedSegment(seg1, segmentMatcher.getDistanceTolerance());
+				if (isMatch) {
+					boolean isTopoEqual = lineSeg0.equalsTopo(lineSeg1);
+					if (!isTopoEqual) {
+						isAdjusted |= seg0.addMatchedSegment(seg1, segmentMatcher.getDistanceTolerance());						
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- Compute shell matches using an STRTree (so nlog(n) matching). Much faster on large polygons.
- Intersect shells symmetrically - match each neighbouring shell pair only one.
- Replace generic JTS hausdorff distance constructor with a method that computes hausdorff distance explicitly between two line segments.
- In segment matcher, check for a hausdorff distance mismatch before an angle mismatch (now faster this way around, with new distance method).
- Reference latest OPENJUMP in .pom (2.2.0-main-SNAPSHOT).